### PR TITLE
fix query order to maintain constraints

### DIFF
--- a/orm/orm.go
+++ b/orm/orm.go
@@ -222,12 +222,12 @@ func GetUnsentMessages(db *sql.DB, maxCnt int) ([]QueuedMessage, error) {
 			}
 
 			for _, id := range messageRowIDs {
-				_, err := tx.Exec("DELETE FROM Messages WHERE Messages.internal_id = $1", &id)
+				_, err := tx.Exec(`UPDATE Attachments SET parent_message = NULL 
+						WHERE parent_message = $0`, &id)
 				if err != nil {
 					return err
 				}
-				_, err = tx.Exec(`UPDATE Attachments SET parent_message = NULL
-				                   WHERE parent_message = $1`, &id)
+				_, err = tx.Exec("DELETE FROM Messages WHERE Messages.internal_id = $1", &id)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
```
2023/03/27 20:52:19 ERROR: update or delete on table "messages" violates foreign key constraint "attachments_parent_message_fkey" on table "attachments" (SQLSTATE 23503)
```
error happened because foreign key dependent row was removed before foreign key was set to NULL